### PR TITLE
Add arm64 to linux build

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [cp38, cp39, cp310, cp311]
-        arch: [x86_64]
+        arch: [x86_64, arm64]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
## Reason for Change
We would like to make `zipline-symforce` package working on `linux-arm64`.

## Description of Change
The `arm64` architecture was added.